### PR TITLE
Page Split Flashing Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kavita-webui",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixed a rare issue where split pages would quickly flash both sides due to previously that page being fetched via onload and thus when render called, render got recalled.

Fixes #74 