### PR TITLE
Bugfixes!

### DIFF
--- a/src/app/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/src/app/_modals/edit-series-modal/edit-series-modal.component.html
@@ -130,7 +130,7 @@
                                                           Chapter: {{file.chapter}}
                                                       </div>
                                                       <div class="col">
-                                                          Pages: {{file.pages}
+                                                          Pages: {{file.pages}}
                                                       </div>
                                                       <div class="col">
                                                           Format: <span class="badge badge-secondary">{{utilityService.mangaFormatToText(file.format)}}</span>

--- a/src/app/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/src/app/_modals/edit-series-modal/edit-series-modal.component.html
@@ -103,10 +103,10 @@
                                   <div>
                                       <div class="row no-gutters">
                                           <div class="col">
-                                              Created: {{volume.created | date: 'dd/MM/yyyy'}}
+                                              Created: {{volume.created | date: 'MM/dd/yyyy'}}
                                           </div>
                                           <div class="col">
-                                              Last Modified: {{volume.lastModified | date: 'dd/MM/yyyy'}}
+                                              Last Modified: {{volume.lastModified | date: 'MM/dd/yyyy'}}
                                           </div>
                                       </div>
                                       <div class="row no-gutters">

--- a/src/app/_modals/edit-series-modal/edit-series-modal.component.html
+++ b/src/app/_modals/edit-series-modal/edit-series-modal.component.html
@@ -6,7 +6,7 @@
         <span aria-hidden="true">&times;</span>
         </button>
     </div>
-    <div class="modal-body">
+    <div class="modal-body scrollable-modal">
         <form [formGroup]="editSeriesForm">
             <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="nav-tabs">
                 <li [ngbNavItem]="tabs[0]">

--- a/src/app/_modals/edit-series-modal/edit-series-modal.component.scss
+++ b/src/app/_modals/edit-series-modal/edit-series-modal.component.scss
@@ -1,0 +1,3 @@
+.scrollable-modal {
+    max-height: 600px;
+}

--- a/src/app/admin/manage-users/manage-users.component.html
+++ b/src/app/admin/manage-users/manage-users.component.html
@@ -16,7 +16,7 @@
                         <button class="btn btn-primary" (click)="openEditLibraryAccess(member)" placement="top" ngbTooltip="Edit" attr.aria-label="Edit {{member.username | titlecase}}"><i class="fa fa-pen" aria-hidden="true"></i></button>
                     </div>
                 </h4>
-                <div>Last Active: {{member.lastActive | date: 'dd/MM/yyyy'}}</div>
+                <div>Last Active: {{member.lastActive | date: 'MM/dd/yyyy'}}</div>
                 <div *ngIf="!member.isAdmin">Sharing: {{formatLibraries(member)}}</div>
             </div>
         </li>

--- a/src/app/series-detail/series-detail.component.html
+++ b/src/app/series-detail/series-detail.component.html
@@ -67,21 +67,21 @@
         </div>
     </div>
     <div class="row">
+        <!-- Special case when the whole series is just one volume and it's a special aka we can't parse vol/chapter from it. -->
+        <div *ngIf="(volumes.length === 1 && volumes[0].number === 0 && chapters.length === 0)">
+            <app-card-item class="col-auto" [entity]="volumes[0]" [title]="series.name" (click)="openVolume(volumes[0])"
+            [imageUrl]="imageService.getVolumeCoverImage(volumes[0].id)"
+            [read]="volumes[0].pagesRead" [total]="volumes[0].pages" [actions]="volumeActions"></app-card-item>
+        </div>
         <div *ngFor="let volume of volumes">
             <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="'Volume ' + volume.name" (click)="openVolume(volume)"
                 [imageUrl]="imageService.getVolumeCoverImage(volume.id)"
                 [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
         </div>
-        <div *ngFor="let chapter of chapters" >
-            <app-card-item class="col-auto" [entity]="chapter" [title]="'Chapter ' + chapter.range" (click)="openChapter(chapter)"
+        <div *ngFor="let chapter of chapters">
+            <app-card-item class="col-auto" [entity]="chapter" [title]="chapter.range === '0' ? 'Specials' : 'Chapter ' + chapter.range" (click)="openChapter(chapter)"
             [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
             [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
-        </div>
-        <!-- Special case when the whole series is just one volume and it's a special aka we can't parse vol/chapter from it. -->
-        <div *ngIf="(volumes.length === 1 && volumes[0].number === 0)">
-            <app-card-item class="col-auto" [entity]="volumes[0]" [title]="series.name" (click)="openVolume(volumes[0])"
-            [imageUrl]="imageService.getVolumeCoverImage(volumes[0].id)"
-            [read]="volumes[0].pagesRead" [total]="volumes[0].pages" [actions]="volumeActions"></app-card-item>
         </div>
     </div>
 </div>

--- a/src/app/series-detail/series-detail.component.scss
+++ b/src/app/series-detail/series-detail.component.scss
@@ -11,6 +11,7 @@
 }
 
 
+
 // Including breakpoint has issue with resovling variable, so copying gridpoints here
 @include media-breakpoint-down(xs, (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px)) {
     .poster {

--- a/src/app/series-detail/series-detail.component.ts
+++ b/src/app/series-detail/series-detail.component.ts
@@ -296,15 +296,13 @@ export class SeriesDetailComponent implements OnInit {
   }
 
   openViewInfo(data: Volume | Chapter) {
-    const modalRef = this.modalService.open(CardDetailsModalComponent, { size: 'lg' });
+    const modalRef = this.modalService.open(CardDetailsModalComponent, { size: 'lg', scrollable: true });
     modalRef.componentInstance.data = data;
     modalRef.componentInstance.parentName = this.series?.name;
   }
 
   openEditSeriesModal() {
-    // TODO: Some library bug with modal where scorllable isn't working. Leave off to use underlying page scroll
-    //scrollable: true,
-    const modalRef = this.modalService.open(EditSeriesModalComponent, {  size: 'lg' });
+    const modalRef = this.modalService.open(EditSeriesModalComponent, {  scrollable: true, size: 'lg', windowClass: 'scrollable-modal' });
     modalRef.componentInstance.series = this.series;
     modalRef.closed.subscribe((closeResult: {success: boolean, series: Series}) => {
       window.scrollTo(0, 0);

--- a/src/app/shared/_modals/card-details-modal/card-details-modal.component.html
+++ b/src/app/shared/_modals/card-details-modal/card-details-modal.component.html
@@ -6,7 +6,7 @@
         <span aria-hidden="true">&times;</span>
         </button>
     </div>
-    <div class="modal-body">
+    <div class="modal-body scrollable-modal">
         <h4 *ngIf="isObjectVolume(this.data)">Information</h4>
         <ng-container *ngIf="isObjectVolume(this.data)">
             <div class="row no-gutters">

--- a/src/app/shared/_modals/card-details-modal/card-details-modal.component.html
+++ b/src/app/shared/_modals/card-details-modal/card-details-modal.component.html
@@ -11,10 +11,10 @@
         <ng-container *ngIf="isObjectVolume(this.data)">
             <div class="row no-gutters">
                 <div class="col">
-                    Created: {{(this.data.created | date: 'dd/MM/yyyy') || '-'}}
+                    Created: {{(this.data.created | date: 'MM/dd/yyyy') || '-'}}
                 </div>
                 <div class="col">
-                    Last Modified: {{(this.data.lastModified | date: 'dd/MM/yyyy') || '-'}}
+                    Last Modified: {{(this.data.lastModified | date: 'MM/dd/yyyy') || '-'}}
                 </div>
             </div>
             <div class="row no-gutters">

--- a/src/app/shared/_modals/card-details-modal/card-details-modal.component.scss
+++ b/src/app/shared/_modals/card-details-modal/card-details-modal.component.scss
@@ -1,0 +1,4 @@
+.scrollable-modal {
+    max-height: 600px;
+    overflow-y: scroll;
+}

--- a/src/app/shared/_modals/card-details-modal/card-details-modal.component.ts
+++ b/src/app/shared/_modals/card-details-modal/card-details-modal.component.ts
@@ -23,13 +23,12 @@ export class CardDetailsModalComponent implements OnInit {
   isChapter = false;
   chapters: Chapter[] = [];
   seriesVolumes: any[] = [];
-  //imageStyles = {width: '74px'};
   isLoadingVolumes = false;
 
   formatKeys = Object.keys(MangaFormat);
 
 
-  constructor(private modalService: NgbModal, public modal: NgbActiveModal, private seriesService: SeriesService, public utilityService: UtilityService, public imageService: ImageService) { }
+  constructor(private modalService: NgbModal, public modal: NgbActiveModal, public utilityService: UtilityService, public imageService: ImageService) { }
 
   ngOnInit(): void {
     this.isChapter = this.isObjectChapter(this.data);
@@ -39,6 +38,7 @@ export class CardDetailsModalComponent implements OnInit {
     } else if (!this.isChapter) {
       this.chapters.push(...this.data?.chapters);
     }
+    this.chapters.sort(this.utilityService.sortChapters);
   }
 
   isObjectChapter(object: any): object is Chapter {


### PR DESCRIPTION
A few small bugfixes that don't break experiences:

Fixes #96 - We have special handling for when a series is just one archive. But the code around it didn't check if there were no volumes and chapters, just volumes. Hence it would show with chapters and since chapters are technically in a 0 volume, they would render twice.

Fixes #93 - This was an off by one issue due to how bookmarks work. Nothing much more to say.

Fixes #97 - I missed a chapter sort on card details modal. In addition, I put a fix for a typo making pages not render and changed info modals to use scrollbars. 