### PR TITLE
Bugfix/misc

### DIFF
--- a/src/app/_services/series.service.ts
+++ b/src/app/_services/series.service.ts
@@ -117,7 +117,7 @@ export class SeriesService {
 
   getMetadata(seriesId: number) {
     return this.httpClient.get<SeriesMetadata>(this.baseUrl + 'series/metadata?seriesId=' + seriesId).pipe(map(items => {
-      items.tags.forEach(tag => tag.coverImage = this.imageService.getCollectionCoverImage(tag.id));
+      items?.tags.forEach(tag => tag.coverImage = this.imageService.getCollectionCoverImage(tag.id));
       return items;
     }));
   }

--- a/src/app/book-reader/book-reader/book-reader.component.html
+++ b/src/app/book-reader/book-reader/book-reader.component.html
@@ -2,13 +2,6 @@
     <div class="fixed-top" #stickyTop>
         <a class="sr-only sr-only-focusable focus-visible" href="javascript:void(0);" (click)="moveFocus()">Skip to main content</a>
         <ng-container [ngTemplateOutlet]="actionBar"></ng-container>
-        <ng-container *ngIf="isLoading">
-            <div class="d-flex justify-content-center m-5">
-                <div class="spinner-border text-secondary loading" role="status">
-                    <span class="invisible">Loading...</span>
-                </div>
-            </div>
-        </ng-container>
         <app-drawer #commentDrawer="drawer" [isOpen]="drawerOpen" [style.--drawer-width]="'300px'" [options]="{topOffset: topOffset}" [style.--drawer-background-color]="backgroundColor" (drawerClosed)="closeDrawer()">
             <div header>
                 <h2 style="margin-top: 0.5rem">Book Settings
@@ -92,6 +85,14 @@
             </div>
         </app-drawer>
     </div>
+
+    <ng-container *ngIf="isLoading">
+        <div class="d-flex justify-content-center m-5">
+            <div class="spinner-border text-secondary loading" role="status">
+                <span class="invisible">Loading...</span>
+            </div>
+        </div>
+    </ng-container>
 
     <div class="overlay" *ngIf="clickToPaginate" >
         <div class="left {{clickToPaginateVisualOverlay ? 'tint' : ''}}" [@fade]="clickToPaginateVisualOverlay" (click)="prevPage()">

--- a/src/app/carousel/carousel-reel/carousel-reel.component.ts
+++ b/src/app/carousel/carousel-reel/carousel-reel.component.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChild, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
+import { AfterContentInit, Component, ContentChild, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
 import Swiper from 'swiper';
 
 @Component({
@@ -6,7 +6,7 @@ import Swiper from 'swiper';
   templateUrl: './carousel-reel.component.html',
   styleUrls: ['./carousel-reel.component.scss']
 })
-export class CarouselReelComponent implements OnInit{
+export class CarouselReelComponent implements OnInit, AfterContentInit{
 
   @ContentChild('carouselItem') carouselItemTemplate!: TemplateRef<any>;
   @Input() items: any[] = [];
@@ -18,6 +18,10 @@ export class CarouselReelComponent implements OnInit{
   constructor() { }
 
   ngOnInit(): void {}
+
+  ngAfterContentInit() {
+    console.log(this.title + ': ', this.carouselItemTemplate);
+  }
 
 
   nextPage() {

--- a/src/app/series-detail/series-detail.component.html
+++ b/src/app/series-detail/series-detail.component.html
@@ -74,22 +74,21 @@
     <hr>
 
 
-    <div *ngIf="hasSpecials; else noSpecials"> <!-- -->
+    <div >
         <ul ngbNav #nav="ngbNav" [(activeId)]="activeTabId" class="nav-tabs" [destroyOnHide]="false">
-            <li [ngbNavItem]="1"> <!--  *ngIf="hasSpecials" (having this will cause the item to not display despite it being true)-->
+            <li [ngbNavItem]="1" *ngIf="!hasNonSpecialVolumeChapters && hasSpecials"> <!--  *ngIf="hasSpecials" (having this will cause the item to not display despite it being true)-->
               <a ngbNavLink>Specials</a>
               <ng-template ngbNavContent>
                 <div class="row">
                     <div *ngFor="let chapter of specials">
-                        <!-- *ngIf="chapter.range !== '0'"-->
-                        <app-card-item class="col-auto" *ngIf="chapter.range !== '0'"  [entity]="chapter" [title]="chapter.title || chapter.range" (click)="openChapter(chapter)"
+                        <app-card-item class="col-auto" *ngIf="chapter.isSpecial"  [entity]="chapter" [title]="chapter.title || chapter.range" (click)="openChapter(chapter)"
                         [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
                         [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
                     </div>
                 </div>
               </ng-template>
             </li>
-            <li [ngbNavItem]="2"> <!--  *ngIf="hasNonSpecialVolumeChapters"-->
+            <li [ngbNavItem]="2" *ngIf="hasNonSpecialVolumeChapters"> <!--  *ngIf="hasNonSpecialVolumeChapters"-->
               <a ngbNavLink>Volumes/Chapters</a>
               <ng-template ngbNavContent>
                   <div class="row">
@@ -99,7 +98,6 @@
                             [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
                     </div>
                     <div *ngFor="let chapter of chapters">
-                        <!-- TOOD: Find a way to show this based on if there is specials or not, so that I can only have code-->
                         <app-card-item class="col-auto" *ngIf="!chapter.isSpecial" [entity]="chapter" [title]="'Chapter ' + chapter.range" (click)="openChapter(chapter)"
                         [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
                         [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
@@ -111,45 +109,9 @@
           <div [ngbNavOutlet]="nav"></div>
     </div>
 
-      <ng-template #noSpecials>
-        <h4>Volumes/Chapters</h4>
-        <div class="row">
-            <div *ngFor="let volume of volumes">
-                <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="'Volume ' + volume.name" (click)="openVolume(volume)"
-                    [imageUrl]="imageService.getVolumeCoverImage(volume.id)"
-                    [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
-            </div>
-            <div *ngFor="let chapter of chapters">
-                <app-card-item class="col-auto" [entity]="chapter" [title]="'Chapter ' + chapter.range" (click)="openChapter(chapter)"
-                [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
-                [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
-            </div>
-        </div>
-      </ng-template>
-
-      <div class="mx-auto" *ngIf="isLoading" style="width: 200px;">
+    <div class="mx-auto" *ngIf="isLoading" style="width: 200px;">
         <div class="spinner-border text-secondary loading" role="status">
             <span class="invisible">Loading...</span>
         </div>
     </div>
-
-    <!-- <div class="row">
-        Special case when the whole series is just one volume and it's a special aka we can't parse vol/chapter from it. 
-        <div>
-            <app-card-item *ngIf="(volumes.length >= 1 && volumes[volumes.length - 1].number === 0 && chapters.length === 0)" class="col-auto" [entity]="volumes[volumes.length - 1]" [title]="'Specials'" (click)="openVolume(volumes[0])"
-            [imageUrl]="imageService.getVolumeCoverImage(volumes[volumes.length - 1].id)"
-            [read]="volumes[volumes.length - 1].pagesRead" [total]="volumes[volumes.length - 1].pages" [actions]="volumeActions"></app-card-item>
-            
-        </div>
-        <div *ngFor="let volume of volumes">
-            <app-card-item class="col-auto" *ngIf="volume.number != 0" [entity]="volume" [title]="'Volume ' + volume.name" (click)="openVolume(volume)"
-                [imageUrl]="imageService.getVolumeCoverImage(volume.id)"
-                [read]="volume.pagesRead" [total]="volume.pages" [actions]="volumeActions"></app-card-item>
-        </div>
-        <div *ngFor="let chapter of chapters">
-            <app-card-item class="col-auto" [entity]="chapter" [title]="chapter.range === '0' ? 'Specials' : 'Chapter ' + chapter.range" (click)="openChapter(chapter)"
-            [imageUrl]="imageService.getChapterCoverImage(chapter.id)"
-            [read]="chapter.pagesRead" [total]="chapter.pages" [actions]="chapterActions"></app-card-item>
-        </div>
-    </div> -->
 </div>

--- a/src/app/shared/series-card/series-card.component.ts
+++ b/src/app/shared/series-card/series-card.component.ts
@@ -95,7 +95,7 @@ export class SeriesCardComponent implements OnInit, OnChanges {
   }
 
   scanLibrary(series: Series) {
-    this.libraryService.scan(this.libraryId).subscribe((res: any) => {
+    this.libraryService.scan(series.libraryId).subscribe((res: any) => {
       this.toastr.success('Scan started for ' + series.name);
     });
   }

--- a/src/app/typeahead/typeahead.component.html
+++ b/src/app/typeahead/typeahead.component.html
@@ -3,7 +3,7 @@
 
 
       <div class="typeahead-input" (click)="onInputFocus($event)">
-        <div class="{{optionSelection.selected().length > 0 ? 'has-items': ''}}">
+        <div>
           <app-tag-badge *ngFor="let option of optionSelection.selected()">
             {{ settings.displayFn(option) }}
             <i class="fa fa-times" (click)="toggleSelection(option)" tabindex="0" aria-label="close"></i>

--- a/src/app/typeahead/typeahead.component.html
+++ b/src/app/typeahead/typeahead.component.html
@@ -17,23 +17,18 @@
       </div>
       <div class="dropdown" *ngIf="hasFocus">
         <ul class="list-group results" #results>
-          <ng-container *ngIf="filteredOptions | async as options">
-            <!-- <li *ngIf="hasFocus && !typeaheadControl.value && (filteredOptions | async)?.length === 0" class="list-group-item">
-            Type to search
-          </li> -->
-            <li *ngIf="showAddItem" 
-              class="list-group-item add-item" role="option" (mouseenter)="focusedIndex = 0; updateHighlight();" (click)="addNewItem(typeaheadControl.value)" >
+          <li *ngIf="showAddItem" 
+              class="list-group-item add-item index-0" role="option" (mouseenter)="focusedIndex = 0; updateHighlight();" (click)="addNewItem(typeaheadControl.value)">
               Add {{typeaheadControl.value}}...
-            </li>
-            <li *ngFor="let option of options; let index = index;" (click)="handleOptionClick(option)"  
-                class="list-group-item" role="option"
-                (mouseenter)="focusedIndex = index + (showAddItem ? 1 : 0); updateHighlight();">
-              <ng-container [ngTemplateOutlet]="optionTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
-            </li>
-            <li *ngIf="options.length === 0 && !showAddItem" class="list-group-item no-hover" role="status">
-              No data{{this.settings.addIfNonExisting ? ', type to add a custom item.' : '.'}}
-            </li>
-          </ng-container>
+          </li>
+          <li *ngFor="let option of filteredOptions | async; let index = index;" (click)="handleOptionClick(option)"  
+              class="list-group-item index-{{index +  + (showAddItem ? 1 : 0)}}" role="option"
+              (mouseenter)="focusedIndex = index + (showAddItem ? 1 : 0); updateHighlight();">
+            <ng-container [ngTemplateOutlet]="optionTemplate" [ngTemplateOutletContext]="{ $implicit: option, idx: index }"></ng-container>
+          </li>
+          <li *ngIf="(filteredOptions | async)?.length === 0 && !showAddItem" class="list-group-item no-hover" role="status">
+            No data{{this.settings.addIfNonExisting ? ', type to add a custom item.' : '.'}}
+          </li>
         </ul>
       </div>
 

--- a/src/app/typeahead/typeahead.component.scss
+++ b/src/app/typeahead/typeahead.component.scss
@@ -55,6 +55,14 @@ input {
     margin-top: -7px;
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
+    position: absolute;
+    max-height: 400px;
+    overflow-y: auto;
+    overflow-x: hidden;
+
+    .list-group-item {
+        padding: 5px 5px;
+    }
 
 
     li {

--- a/src/app/typeahead/typeahead.component.scss
+++ b/src/app/typeahead/typeahead.component.scss
@@ -4,13 +4,13 @@ input {
     width: 15px;
     opacity: 1px;
     position: relative;
-    left: 0px;
+    left: 4px;
     border: none;
 }
 
 .typeahead-input {
     border: 1px solid #ccc;
-    padding: 6px 12px;
+    padding: 4px 6px;
     display: inline-block;
     width: 100%;
     overflow: hidden;
@@ -20,9 +20,8 @@ input {
     box-shadow: none;
     border-radius: 4px;
     cursor: text;
-    min-height: 34px;
     background-color: #fff;
-
+    min-height: 38px;
 
     input {
         outline: 0 !important;
@@ -35,11 +34,6 @@ input {
         text-indent: 0 !important;
         line-height: inherit !important;
         box-shadow: none !important;
-    }
-
-    .has-items {
-        padding-left: 9px;
-        padding-right: 9px;
     }
 }
 

--- a/src/app/typeahead/typeahead.component.ts
+++ b/src/app/typeahead/typeahead.component.ts
@@ -260,6 +260,7 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
 
             this.filteredOptions.pipe(take(1)).subscribe((res: any[]) => {  
               // This isn't giving back the filtered array, but everything
+              //console.log(res);
               const result = res.filter((item: any, index: number) => index === focusedIndex);
               if (result.length === 1) {
                 if (item.classList.contains('add-item')) {
@@ -368,6 +369,7 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
       this.renderer2.setStyle(this.inputElem.nativeElement, 'width', 4, RendererStyleFlags2.Important);  
     }
     this.typeaheadControl.setValue('');
+    this.focusedIndex = 0;
   }
 
   // Updates the highlight to focus on the selected item

--- a/src/app/typeahead/typeahead.component.ts
+++ b/src/app/typeahead/typeahead.component.ts
@@ -1,7 +1,7 @@
 import { Component, ContentChild, ElementRef, EventEmitter, HostListener, Input, OnDestroy, OnInit, Output, Renderer2, RendererStyleFlags2, TemplateRef, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Observable, Observer, of, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, shareReplay, switchMap, take, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, last, map, shareReplay, switchMap, take, takeLast, takeUntil, tap, withLatestFrom } from 'rxjs/operators';
 import { KEY_CODES } from '../shared/_services/utility.service';
 import { TypeaheadSettings } from './typeahead-settings';
 
@@ -169,8 +169,8 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
         // Adjust input box to grow
         tap(val => {
           if (this.inputElem != null && this.inputElem.nativeElement != null) {
-            console.log(this.inputElem.nativeElement.value);
             this.renderer2.setStyle(this.inputElem.nativeElement, 'width', 15 * ((this.typeaheadControl.value + '').length + 1) + 'px');
+            this.focusedIndex = 0;
           }
         }),
         debounceTime(this.settings.debounce),
@@ -200,8 +200,8 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
           this.isLoadingOptions = false; 
           this.focusedIndex = 0; 
           setTimeout(() => {
-            this.updateHighlight();
             this.updateShowAddItem(val);
+            this.updateHighlight();
           }, 10);
         }),
         shareReplay(),
@@ -250,14 +250,25 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
       {
         document.querySelectorAll('.list-group-item').forEach((item, index) => {
           if (item.classList.contains('active')) {
-            this.filteredOptions.pipe(take(1)).subscribe((res: any) => {
-              var result = res.filter((item: any, index: number) => index === this.focusedIndex);
+            const classes = [...item.classList.value.split(' ')];
+            const indexClass = classes.filter(item => item.startsWith('index-'));
+            let focusedIndex = this.focusedIndex;
+            if (indexClass.length > 0) {
+              focusedIndex = parseInt(indexClass[0].split('-')[1], 10); 
+              console.log('index: ', index);
+            }
+
+            this.filteredOptions.pipe(take(1)).subscribe((res: any[]) => {  
+              // This isn't giving back the filtered array, but everything
+              const result = res.filter((item: any, index: number) => index === focusedIndex);
               if (result.length === 1) {
                 if (item.classList.contains('add-item')) {
-                  this.addNewItem(this.typeaheadControl.value)
+                  this.addNewItem(this.typeaheadControl.value);
                 } else {
                   this.toggleSelection(result[0]);
                 }
+                this.resetField();
+                this.focusedIndex = 0;
               }
             });
           }
@@ -276,6 +287,10 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
         }
         break;
       }
+      case KEY_CODES.ESC_KEY:
+        this.hasFocus = false;
+        event.stopPropagation();
+        break;
       default:
         break;
     }
@@ -338,9 +353,6 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
       event.stopPropagation();
       event.preventDefault();
     }
-    
-
-    //if (this.hasFocus) { return; }
 
     if (this.inputElem) {
       this.inputElem.nativeElement.focus();
@@ -348,7 +360,6 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
     }
    
     this.openDropdown();
-    //this.isLoadingOptions = true;
   }
 
 
@@ -377,6 +388,7 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
           && this.typeaheadControl.value.trim().length >= Math.max(this.settings.minCharacters, 1) 
           && this.typeaheadControl.dirty
           && (typeof this.settings.compareFn == 'function' && this.settings.compareFn(options, this.typeaheadControl.value.trim()).length === 0);
+
   }
 
 }


### PR DESCRIPTION
Fixes #178 

# Changed
- Changed Tabs on Series Detail to now be "smart". The tabs now auto-select based on the data. 
- Typeahead items are now thinner and use absolute positioning so that the overlay doesn't push content

# Fixed
- Lots of accessibility issues in the typeahead (some still broken)
- Fixed an exception when collection tags are null due to a bug in previous release
- Fixed a bug where opening settings sidenav then navigating to a new page in book reader would push the side nav down
- Fixed an issue where carousel series card scan library would kick off the wrong library