### PR TITLE
Adding Recently Added Page

### DIFF
--- a/src/app/_services/series.service.ts
+++ b/src/app/_services/series.service.ts
@@ -20,6 +20,7 @@ export class SeriesService {
   baseUrl = environment.apiUrl;
   paginatedResults: PaginatedResult<Series[]> = new PaginatedResult<Series[]>();
   paginatedSeriesForTagsResults: PaginatedResult<Series[]> = new PaginatedResult<Series[]>();
+  paginatedSeriesForRecentResults: PaginatedResult<Series[]> = new PaginatedResult<Series[]>();
 
   constructor(private httpClient: HttpClient, private imageService: ImageService) { }
 
@@ -90,8 +91,8 @@ export class SeriesService {
     return this.httpClient.post<void>(this.baseUrl + 'reader/mark-unread', {seriesId});
   }
 
-  getRecentlyAdded(libraryId: number = 0) {
-    return this.httpClient.get<Series[]>(this.baseUrl + 'series/recently-added?libraryId=' + libraryId).pipe(map(series => {
+  getRecentlyAdded(libraryId: number = 0, limit: number) {
+    return this.httpClient.get<Series[]>(this.baseUrl + 'series/recently-added?libraryId=' + libraryId + '&limit=' + limit).pipe(map(series => {
       series.forEach(s => s.coverImage = this.imageService.getSeriesCoverImage(s.id));
       return series;
     }));
@@ -143,6 +144,19 @@ export class SeriesService {
       })
     );
   }
+
+  getSeriesForRecent(pageNum?: number, itemsPerPage?: number) {
+    let params = new HttpParams();
+
+    params = this._addPaginationIfExists(params, pageNum, itemsPerPage);
+    return this.httpClient.get<PaginatedResult<Series[]>>(this.baseUrl + 'series/series-by-recently-added', {observe: 'response', params}).pipe(
+      map((response: any) => {
+        return this._cachePaginatedResults(response, this.paginatedSeriesForRecentResults);
+      })
+    );
+    
+  }
+
 
   _addPaginationIfExists(params: HttpParams, pageNum?: number, itemsPerPage?: number) {
     if (pageNum !== null && pageNum !== undefined && itemsPerPage !== null && itemsPerPage !== undefined) {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AllCollectionsComponent } from './all-collections/all-collections.component';
+import { RecentlyAddedComponent } from './recently-added/recently-added.component';
 import { HomeComponent } from './home/home.component';
 import { LibraryDetailComponent } from './library-detail/library-detail.component';
 import { LibraryComponent } from './library/library.component';
@@ -42,8 +43,7 @@ const routes: Routes = [
     runGuardsAndResolvers: 'always',
     canActivate: [AuthGuard],
     children: [
-      //{path: 'recently-added', component: RecentlyAddedComponent},
-        
+      {path: 'recently-added', component: RecentlyAddedComponent},  
       {path: 'collections', component: AllCollectionsComponent},
       {path: 'collections/:id', component: AllCollectionsComponent},
     ]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { PersonBadgeComponent } from './person-badge/person-badge.component';
 import { TypeaheadModule } from './typeahead/typeahead.module';
 import { AllCollectionsComponent } from './all-collections/all-collections.component';
 import { EditCollectionTagsComponent } from './_modals/edit-collection-tags/edit-collection-tags.component';
+import { RecentlyAddedComponent } from './recently-added/recently-added.component';
 
 let sentryProviders: any[] = [];
 
@@ -100,7 +101,7 @@ if (environment.production) {
     UserPreferencesComponent, // Move into SettingsModule
     EditSeriesModalComponent, 
     ReviewSeriesModalComponent, 
-    PersonBadgeComponent, AllCollectionsComponent, EditCollectionTagsComponent, 
+    PersonBadgeComponent, AllCollectionsComponent, EditCollectionTagsComponent, RecentlyAddedComponent, 
   ],
   imports: [
     HttpClientModule,

--- a/src/app/library-detail/library-detail.component.ts
+++ b/src/app/library-detail/library-detail.component.ts
@@ -42,9 +42,11 @@ export class LibraryDetailComponent implements OnInit {
         this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
       }
       this.pagination.currentPage = parseInt(page, 10);
+    } else {
+      this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
     }
     this.loadingSeries = true;
-    this.seriesService.getSeriesForLibrary(this.libraryId, this.pagination.currentPage, this.pagination.itemsPerPage).subscribe(series => {
+    this.seriesService.getSeriesForLibrary(this.libraryId, this.pagination?.currentPage, this.pagination?.itemsPerPage).subscribe(series => {
       this.series = series.result;
       this.pagination = series.pagination;
       this.loadingSeries = false;

--- a/src/app/library/library.component.ts
+++ b/src/app/library/library.component.ts
@@ -53,7 +53,7 @@ export class LibraryComponent implements OnInit {
   }
 
   reloadSeries() {
-    this.seriesService.getRecentlyAdded().subscribe((series) => {
+    this.seriesService.getRecentlyAdded(0, 20).subscribe((series) => {
       this.recentlyAdded = series;
     });
 

--- a/src/app/recently-added/recently-added.component.html
+++ b/src/app/recently-added/recently-added.component.html
@@ -1,0 +1,12 @@
+<ng-container>
+    <app-card-detail-layout header="Recently Added" 
+    [isLoading]="isLoading"
+    [items]="recentlyAdded"
+    [pagination]="pagination"
+    (pageChange)="onPageChange($event)"
+    >
+        <ng-template #cardItem let-item let-position="idx">
+            <app-series-card [data]="item" [libraryId]="item.libraryId" (reload)="loadPage()"></app-series-card>
+        </ng-template>
+    </app-card-detail-layout>
+</ng-container>

--- a/src/app/recently-added/recently-added.component.ts
+++ b/src/app/recently-added/recently-added.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { take } from 'rxjs/operators';
+import { ToastrService } from 'ngx-toastr';
+import { EditCollectionTagsComponent } from '../_modals/edit-collection-tags/edit-collection-tags.component';
+import { CollectionTag } from '../_models/collection-tag';
+import { Pagination } from '../_models/pagination';
+import { Series } from '../_models/series';
+import { Library } from '../_models/library';
+import { User } from '../_models/user';
+import { Action, ActionFactoryService, ActionItem } from '../_services/action-factory.service';
+import { SeriesService } from '../_services/series.service';
+import { CollectionTagService } from '../_services/collection-tag.service';
+import { AccountService } from '../_services/account.service';
+
+/**
+ * This component is used as a standard layout for any card detail. ie) series, in-progress, collections, etc. 
+ */
+@Component({
+  selector: 'app-recently-added',
+  templateUrl: './recently-added.component.html',
+  styleUrls: ['./recently-added.component.scss']
+})
+export class RecentlyAddedComponent implements OnInit {
+
+  isLoading: boolean = true;
+  collections: CollectionTag[] = [];
+  recentlyAdded: Series[] = [];
+  series: Array<Series> = [];
+  collectionTagActions: ActionItem<CollectionTag>[] = [];
+  user: User | undefined;
+  libraries: Library[] = [];
+  isAdmin = false;
+  pagination!: Pagination;
+  libraryId!: number;
+
+  constructor(public accountService: AccountService, private router: Router, 
+    private route: ActivatedRoute, private seriesService: SeriesService, private toastr: ToastrService, 
+    private collectionService: CollectionTagService, private actionFactoryService: ActionFactoryService, private modalService: NgbModal) {
+    this.router.routeReuseStrategy.shouldReuseRoute = () => false;
+
+    const routeId = this.route.snapshot.paramMap.get('id');
+  }
+
+  ngOnInit() {
+    this.loadPage();
+  }
+
+  seriesClicked(series: Series) {
+    this.router.navigate(['library', this.libraryId, 'series', series.id]);
+  }
+
+  onPageChange(pagination: Pagination) {
+    this.router.navigate(['recently-added'], {replaceUrl: true, queryParamsHandling: 'merge', queryParams: {page: this.pagination.currentPage} });
+  }
+
+  loadPage() {
+    // TODO: See if we can move this pagination code into layout code
+    const page = this.route.snapshot.queryParamMap.get('page');
+    if (page != null) {
+      if (this.pagination == undefined || this.pagination == null) {
+        this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
+      }
+      this.pagination.currentPage = parseInt(page, 10);
+    } else {
+      this.pagination = {currentPage: 0, itemsPerPage: 30, totalItems: 0, totalPages: 1};
+    }
+    // Reload page after a series is updated or first load
+      this.seriesService.getSeriesForRecent(this.pagination?.currentPage, this.pagination?.itemsPerPage).subscribe(series => {
+        this.recentlyAdded = series.result;
+        this.pagination = series.pagination;
+        this.isLoading = false;
+        window.scrollTo(0, 0);
+        console.log(series);
+      });
+    }
+}


### PR DESCRIPTION
- Tweaked Recently Added function for homepage carousel to have a custom limit.
- Fixed library-detail page to prevent route return and added pagination item limit of 30.
- Added new function in series service to return paginated headers for Recently Added page.

Closes #184 