### PR TITLE
Book Reader - Scroll Position Tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "kavita-webui",
       "version": "0.4.1",
       "dependencies": {
         "@angular-slider/ngx-slider": "^2.0.3",

--- a/src/app/book-reader/book-reader/book-reader.component.html
+++ b/src/app/book-reader/book-reader/book-reader.component.html
@@ -81,7 +81,9 @@
                                 {{chapterGroup.title}}
                             </li>
                             <ul *ngFor="let chapter of chapterGroup.children">
-                                <li><a href="javascript:void(0);" (click)="loadChapter(chapter.page, chapter.part)">{{chapter.title}}</a></li>
+                                <li class="{{cleanIdSelector(chapter.part) === currentPageAnchor ? 'active' : ''}}">
+                                    <a href="javascript:void(0);" (click)="loadChapter(chapter.page, chapter.part)">{{chapter.title}}</a>
+                                </li>
                             </ul>
                         </ul>
                     </ng-template>

--- a/src/app/typeahead/typeahead.component.ts
+++ b/src/app/typeahead/typeahead.component.ts
@@ -365,15 +365,12 @@ export class TypeaheadComponent implements OnInit, OnDestroy {
 
   // Updates the highlight to focus on the selected item
   updateHighlight() {
-    console.log('updating highlight for index: ', this.focusedIndex);
     document.querySelectorAll('.list-group-item').forEach((item, index) => {
       if (index === this.focusedIndex && !item.classList.contains('no-hover')) {
         // apply active class
-        console.log('Adding to ', item.textContent);
         this.renderer2.addClass(item, 'active');
       } else {
         // remove active class
-        console.log('Removing from ', item.textContent);
         this.renderer2.removeClass(item, 'active');
       }
     });

--- a/src/assets/themes/dark.scss
+++ b/src/assets/themes/dark.scss
@@ -9,6 +9,7 @@ $dark-link-color: rgb(88, 166, 255);
 $dark-icon-color: white;
 $dark-form-border: rgba(239, 239, 239, 0.125);
 $dark-form-readonly: #434648;
+$dark-item-accent-bg: #292d32;
 
 .bg-dark {
   color: $dark-text-color;
@@ -22,7 +23,7 @@ $dark-form-readonly: #434648;
   }
 
   .breadcrumb {
-    background-color: #292d32;
+    background-color: $dark-item-accent-bg;
 
     .breadcrumb-item {
       color: $dark-text-color;


### PR DESCRIPTION
Cleaned up some console.logs and tweaked the logic of scroll position remembering. 

# Added
- Now the side nav chapter list will show what part you are on (if applicable) based on scroll position. This ties directly in with the bookmark which will restore scroll position on next load of book.

Fixes #212 