### PR TITLE
Css fix for book reader progress and light mode toastr

### DIFF
--- a/src/app/book-reader/book-reader/book-reader.component.html
+++ b/src/app/book-reader/book-reader/book-reader.component.html
@@ -65,7 +65,7 @@
                 <div class="row no-gutters">
                     <div class="col-1">{{pageNum}}</div>
                     <div class="col-10" style="margin-top: 9px">
-                        <ngb-progressbar style="cursor: pointer" title="Go to page" (click)="goToPage()" type="warning" height="5px" [value]="pageNum" [max]="maxPages - 1"></ngb-progressbar>
+                        <ngb-progressbar style="cursor: pointer" title="Go to page" (click)="goToPage()" type="primary" height="5px" [value]="pageNum" [max]="maxPages - 1"></ngb-progressbar>
                     </div>
                     <div class="col-1">{{maxPages - 1}}</div>
                 </div>

--- a/src/theme/_toastr.scss
+++ b/src/theme/_toastr.scss
@@ -144,7 +144,6 @@
     margin-right: auto;
   }
   .ngx-toastr {
-    background-color: #030303;
     pointer-events: auto;
   }
   .toast-progress {


### PR DESCRIPTION
- Changed bookreader progressbar from warning to primary (green)
- Removed main toastr color to prevent override on light mode

Closes #258 